### PR TITLE
Wuf 77 deply nonroot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
         entrypoint: /bin/sh
     working_directory: ~/wuf
     environment:
-      - DEPLOY_BRANCH: master
+      - DEPLOY_BRANCH: WUF-77-deply-nonroot
       - TARGET_BRANCH: gh-pages
       - GH_EMAIL: anvil.open.source.machine.user@gmail.com
       - GH_NAME: anvil-open-source-machine-user
@@ -79,10 +79,10 @@ jobs:
               # For branches other than master, append an unique value to
               # provent build failures.
               GITTAG=v$(npx -c 'echo "$npm_package_version"')
-              # if [ $DEPLOY_BRANCH != $MASTER_BRANCH ]; then
-              # 	SECONDS_SINCE_EPOCH=$(date +%s)
-              # 	GITTAG=$(echo $GITTAG-$SECONDS_SINCE_EPOCH)
-              # fi
+              if [ $DEPLOY_BRANCH != $MASTER_BRANCH ]; then
+              	SECONDS_SINCE_EPOCH=$(date +%s)
+              	GITTAG=$(echo $GITTAG-$SECONDS_SINCE_EPOCH)
+              fi
               echo Taging $CIRCLE_BRANCH: $GITTAG
 
               # Using annotated tags; required to include tag to prevent build from running

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: Build WUF
           command: |
-            ng build --prod --base-href https://anvil-open-software.github.io/wuf/
+            ng build --prod --base-href https://anvil-open-software.github.io/wuf/ --deploy-url https://anvil-open-software.github.io/wuf/
       - run:
           name: Test WUF
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     working_directory: ~/wuf
     environment:
       - MASTER_BRANCH: master
-      - DEPLOY_BRANCH: WUF-77-deply-nonroot
+      - DEPLOY_BRANCH: WUF-77-deply-nonroot-favicon
       - TARGET_BRANCH: gh-pages
       - GH_EMAIL: anvil.open.source.machine.user@gmail.com
       - GH_NAME: anvil-open-source-machine-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     working_directory: ~/wuf
     environment:
       - MASTER_BRANCH: master
-      - DEPLOY_BRANCH: WUF-77-deply-nonroot-favicon
+      - DEPLOY_BRANCH: WUF-77-deply-nonroot
       - TARGET_BRANCH: gh-pages
       - GH_EMAIL: anvil.open.source.machine.user@gmail.com
       - GH_NAME: anvil-open-source-machine-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: Build WUF
           command: |
-            ng build --aot --base-href https://anvil-open-software.github.io/wuf/
+            ng build --prod --base-href https://anvil-open-software.github.io/wuf/
       - run:
           name: Test WUF
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     working_directory: ~/wuf
     environment:
       - MASTER_BRANCH: master
-      - DEPLOY_BRANCH: WUF-77-deply-nonroot
+      - DEPLOY_BRANCH: master
       - TARGET_BRANCH: gh-pages
       - GH_EMAIL: anvil.open.source.machine.user@gmail.com
       - GH_NAME: anvil-open-source-machine-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: Build WUF
           command: |
-            ng build --prod --base-href https://anvil-open-software.github.io/wuf/ --deploy-url https://anvil-open-software.github.io/wuf/
+            ng build --prod --base-href /wuf/ --deploy-url https://anvil-open-software.github.io/wuf/
       - run:
           name: Test WUF
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,7 @@ jobs:
               # provent build failures.
               GITTAG=v$(npx -c 'echo "$npm_package_version"')
               if [ $DEPLOY_BRANCH != $MASTER_BRANCH ]; then
-              	SECONDS_SINCE_EPOCH=$(date +%s)
-              	GITTAG=$(echo $GITTAG-$SECONDS_SINCE_EPOCH)
+              	GITTAG=$(echo $GITTAG-Build.$CIRCLE_BUILD_NUM)
               fi
               echo Taging $CIRCLE_BRANCH: $GITTAG
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: Build WUF
           command: |
-            ng build --aot --base-href /wuf/ --deploy-url /wuf/
+            ng build --aot --deploy-url https://anvil-open-software.github.io/wuf/
       - run:
           name: Test WUF
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
         entrypoint: /bin/sh
     working_directory: ~/wuf
     environment:
+      - MASTER_BRANCH: master
       - DEPLOY_BRANCH: WUF-77-deply-nonroot
       - TARGET_BRANCH: gh-pages
       - GH_EMAIL: anvil.open.source.machine.user@gmail.com

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: Build WUF
           command: |
-            ng build --aot --deploy-url https://anvil-open-software.github.io/wuf/
+            ng build --aot --base-href https://anvil-open-software.github.io/wuf/
       - run:
           name: Test WUF
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-rc.12] - 2019-05-31
+### Fixed
+- Certain assets are not handled correctly when deploying to GitHub Pages.
+
 ## [2.0.0-rc.11] - 2019-05-08
 ### Added
 - Added continuous build and continuous deployment to [GitHub](https://anvil-open-software.github.io/wuf/); this is work in progress, with the outstanding issue being:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anviltech/wuf-web-ui-framework",
-  "version": "2.0.0-rc.11",
+  "version": "2.0.0-rc.12",
   "author": "Darren Luvaas",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "ng": "ng",
     "start": "ng serve --aot",
     "build": "ng build --aot",
+    "build:reset": "rm -rf node_modules && yarn bootstrap && yarn build",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --aot",
+    "start:reset": "yearn build:reset && ng serve --aot",
     "build": "ng build --aot",
     "build:reset": "rm -rf node_modules && yarn bootstrap && yarn build",
     "test": "ng test",

--- a/src/app/pages/app-setup/main-basic/main-basic.component.html
+++ b/src/app/pages/app-setup/main-basic/main-basic.component.html
@@ -35,12 +35,12 @@
         <div class="row swatch-row">
             <div class="col-md">
                 <h4 class="text-center">Main Layout</h4>
-                <img src="/assets/images/example_images/layouts/main.svg">
+                <img src="assets/images/example_images/layouts/main.svg">
             </div>
 
             <div class="col-md">
                 <h4 class="text-center">Basic Layout</h4>
-                <img src="/assets/images/example_images/layouts/basic.svg">
+                <img src="assets/images/example_images/layouts/basic.svg">
             </div>
 
         </div>

--- a/src/app/pages/components/card/card.component.html
+++ b/src/app/pages/components/card/card.component.html
@@ -33,7 +33,7 @@
                     <mat-card-title>Shiba Inu</mat-card-title>
                     <mat-card-subtitle>Dog Breed</mat-card-subtitle>
                 </mat-card-header>
-                <img mat-card-image src="../../../../assets/images/example_images/card/shiba2.jpg" alt="Photo of a Shiba Inu">
+                <img mat-card-image src="/assets/images/example_images/card/shiba2.jpg" alt="Photo of a Shiba Inu">
                 <mat-card-content>
                     <p>
                         The Shiba Inu is the smallest of the six original and distinct spitz breeds of dog from Japan.

--- a/src/app/pages/components/card/card.component.html
+++ b/src/app/pages/components/card/card.component.html
@@ -33,7 +33,7 @@
                     <mat-card-title>Shiba Inu</mat-card-title>
                     <mat-card-subtitle>Dog Breed</mat-card-subtitle>
                 </mat-card-header>
-                <img mat-card-image src="/assets/images/example_images/card/shiba2.jpg" alt="Photo of a Shiba Inu">
+                <img mat-card-image src="assets/images/example_images/card/shiba2.jpg" alt="Photo of a Shiba Inu">
                 <mat-card-content>
                     <p>
                         The Shiba Inu is the smallest of the six original and distinct spitz breeds of dog from Japan.

--- a/src/app/pages/components/card/card.component.html
+++ b/src/app/pages/components/card/card.component.html
@@ -33,7 +33,7 @@
                     <mat-card-title>Shiba Inu</mat-card-title>
                     <mat-card-subtitle>Dog Breed</mat-card-subtitle>
                 </mat-card-header>
-                <img mat-card-image src="assets/images/example_images/card/shiba2.jpg" alt="Photo of a Shiba Inu">
+                <img mat-card-image src="../../../../assets/images/example_images/card/shiba2.jpg" alt="Photo of a Shiba Inu">
                 <mat-card-content>
                     <p>
                         The Shiba Inu is the smallest of the six original and distinct spitz breeds of dog from Japan.

--- a/src/app/pages/components/card/card.component.scss
+++ b/src/app/pages/components/card/card.component.scss
@@ -8,6 +8,6 @@
 }
 
 .example-header-image {
-    background-image: url("assets/images/example_images/card/shiba1.jpg");
+    background-image: url("/assets/images/example_images/card/shiba1.jpg");
     background-size: cover;
 }

--- a/src/app/pages/components/card/card.component.scss
+++ b/src/app/pages/components/card/card.component.scss
@@ -8,6 +8,6 @@
 }
 
 .example-header-image {
-    background-image: url("../../../../assets/images/example_images/card/shiba1.jpg");
+    background-image: url("/assets/images/example_images/card/shiba1.jpg");
     background-size: cover;
 }

--- a/src/app/pages/components/card/card.component.scss
+++ b/src/app/pages/components/card/card.component.scss
@@ -8,6 +8,6 @@
 }
 
 .example-header-image {
-    background-image: url("/assets/images/example_images/card/shiba1.jpg");
+    background-image: url("assets/images/example_images/card/shiba1.jpg");
     background-size: cover;
 }

--- a/src/app/pages/components/card/card.component.scss
+++ b/src/app/pages/components/card/card.component.scss
@@ -8,6 +8,6 @@
 }
 
 .example-header-image {
-    background-image: url("assets/images/example_images/card/shiba1.jpg");
+    background-image: url("../../../../assets/images/example_images/card/shiba1.jpg");
     background-size: cover;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -16,26 +16,26 @@
 
     <!-- begin favicons -->
     <!-- www.favicomatic.com -->
-    <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/assets/images/favicons/apple-touch-icon-57x57.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/assets/images/favicons/apple-touch-icon-114x114.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/assets/images/favicons/apple-touch-icon-72x72.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/assets/images/favicons/apple-touch-icon-144x144.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="60x60" href="/assets/images/favicons/apple-touch-icon-60x60.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/assets/images/favicons/apple-touch-icon-120x120.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="/assets/images/favicons/apple-touch-icon-76x76.png" />
-    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/assets/images/favicons/apple-touch-icon-152x152.png" />
-    <link rel="icon" type="image/png" href="/assets/images/favicons/favicon-196x196.png" sizes="196x196" />
-    <link rel="icon" type="image/png" href="/assets/images/favicons/favicon-96x96.png" sizes="96x96" />
-    <link rel="icon" type="image/png" href="/assets/images/favicons/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="/assets/images/favicons/favicon-16x16.png" sizes="16x16" />
-    <link rel="icon" type="image/png" href="/assets/images/favicons/favicon-128.png" sizes="128x128" />
+    <link rel="apple-touch-icon-precomposed" sizes="57x57" href="assets/images/favicons/apple-touch-icon-57x57.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="assets/images/favicons/apple-touch-icon-114x114.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="assets/images/favicons/apple-touch-icon-72x72.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="assets/images/favicons/apple-touch-icon-144x144.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="60x60" href="assets/images/favicons/apple-touch-icon-60x60.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="assets/images/favicons/apple-touch-icon-120x120.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="assets/images/favicons/apple-touch-icon-76x76.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="assets/images/favicons/apple-touch-icon-152x152.png" />
+    <link rel="icon" type="image/png" href="assets/images/favicons/favicon-196x196.png" sizes="196x196" />
+    <link rel="icon" type="image/png" href="assets/images/favicons/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/png" href="assets/images/favicons/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="assets/images/favicons/favicon-16x16.png" sizes="16x16" />
+    <link rel="icon" type="image/png" href="assets/images/favicons/favicon-128.png" sizes="128x128" />
     <meta name="application-name" content="&nbsp;"/>
     <meta name="msapplication-TileColor" content="#FFFFFF" />
-    <meta name="msapplication-TileImage" content="/assets/images/favicons/mstile-144x144.png" />
-    <meta name="msapplication-square70x70logo" content="/assets/images/favicons/mstile-70x70.png" />
-    <meta name="msapplication-square150x150logo" content="/assets/images/favicons/mstile-150x150.png" />
-    <meta name="msapplication-wide310x150logo" content="/assets/images/favicons/mstile-310x150.png" />
-    <meta name="msapplication-square310x310logo" content="/assets/images/favicons/mstile-310x310.png" />
+    <meta name="msapplication-TileImage" content="assets/images/favicons/mstile-144x144.png" />
+    <meta name="msapplication-square70x70logo" content="assets/images/favicons/mstile-70x70.png" />
+    <meta name="msapplication-square150x150logo" content="assets/images/favicons/mstile-150x150.png" />
+    <meta name="msapplication-wide310x150logo" content="assets/images/favicons/mstile-310x150.png" />
+      <meta name="msapplication-square310x310logo" content="assets/images/favicons/mstile-310x310.png" />
     <!-- end favicons -->
 
     <script>


### PR DESCRIPTION
Acceptance Criteria

**Given** the DevOps person wants to deploy the living style guide
**When** the DevOps person selects a deployment location (E.g., host, port, base path)
**Then** the DevOps person can set the base path on the command line at build/deploy time (no code change required)

**Note**:

- CircleCI, Jenkins are ‘DevOps person’
- Change to host and port must be possible at any time
- Work being done in WUF, in the WUF-77

Links and References:

-Relevant
  - Not able to deploy Angular7 app on github pages - First time I saw a reference to suing the WHOLE target deployment URL, --deploy-url https://anvil-open-software.github.io/wuf/
  - The Base-href/deploy-url parameters don't work as expected: paths aren't changed after building - got the idea of combining --base-ref /wuf/ with --deploy-url https://anvil-open-software.github.io/wuf/
- Discarded
  - using deploy-url and base-href yields in wrong assets path
  - ng-cli build
  - Angular Workspace Configuration
  - Karma Configuration File
  - Not able to deploy Angular7 app on github pages -
  - The Base-href/deploy-url parameters don't work as expected: paths aren't changed after building - got the idea of using base-ref /wuf /

**Resolution**
- The `img` tag i`mage URL` must be a relative path;
- The build command to deploy at GitHub Pages must be as follows:
   - `ng build --prod --base-href /wuf/ --deploy-url https://anvil-open-software.github.io/wuf/ `
- Image URLs in templates must be absolute
- Image URLs in SCCS must be relative

Unfortunately, I found this by trial and error and do not have a robust explanation.