### PR TITLE
Wuf 94 lerna version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,10 +71,6 @@ jobs:
               command: |
                  ng test --karmaConfig=src/karma.conf.circleci.js
          - run:
-              name: Tag WUF
-              command: |
-                 ./.circleci/tag.sh
-         - run:
               name: Deploy WUF
               command: |
                  ./.circleci/deploy.sh
@@ -82,3 +78,7 @@ jobs:
               name: Publish changed packages
               command: |
                  ./.circleci/publish.sh
+         - run:
+              name: Tag WUF
+              command: |
+                 ./.circleci/tag.sh

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --aot",
-    "start:reset": "yearn build:reset && ng serve --aot",
+    "start:reset": "yarn build:reset && ng serve --aot",
     "build": "ng build --aot",
     "build:reset": "rm -rf node_modules && yarn bootstrap && yarn build",
     "test": "ng test",


### PR DESCRIPTION
@lerna/version is designed to change packages' versions in a bulk fashion, e.g., bump all minor versions. I find this inappropriate since it is likely some packages might require a minor version upgrade whereas another an upgrade from a feature to an x.y.z version. Therefore we will leave it as is for now and keep an eye on lerna watching for changes that make it more flexible to include in a CI/CD pipeline.

Fixed a typo on a script and changed the order of scripts, making the tag the last one. Hence the tag is created only after everything works.